### PR TITLE
Add requirements.txt with project dependencie

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,6 @@
+asgiref==3.8.1
+dj-database-url==2.1.0
+Django==4.2.11
+psycopg2-binary==2.9.9
+sqlparse==0.5.0
+typing_extensions==4.11.0


### PR DESCRIPTION
Whenever you or someone else needs to set up the project environment (e.g., on a different machine or in a deployment pipeline), you can simply run:
`pip install -r requirements.txt`